### PR TITLE
request_uri deprecation

### DIFF
--- a/lib/render_caching/controller_additions.rb
+++ b/lib/render_caching/controller_additions.rb
@@ -3,7 +3,7 @@ module RenderCaching
     private
     
     def render_with_cache(key = nil, options = nil)
-      key ||= request.request_uri
+      key ||= request.fullpath
       body = Rails.cache.read(key)
       if body
         render :text => body

--- a/spec/render_caching/controller_additions_spec.rb
+++ b/spec/render_caching/controller_additions_spec.rb
@@ -29,7 +29,7 @@ describe RenderCaching::ControllerAdditions do
   end
   
   it "should read from the cache with request uri as key and render that text" do
-    @request.stubs(:request_uri).returns('/foo/bar')
+    @request.stubs(:fullpath).returns('/foo/bar')
     Rails.cache.write('/foo/bar', 'page content')
     expects(:render).with(:text => 'page content')
     render_with_cache


### PR DESCRIPTION
I don't know if you are still maintaining this gem, but I am using it in my Rails 3 project, and I wanted to resolve the deprecation warnings. 

I changed #request_uri to #fullpath: http://api.rubyonrails.org/classes/ActionDispatch/Http/URL.html#method-i-request_uri

Thanks!
